### PR TITLE
Support for pack.metadata.entity in addition to pack.metadata.type for compendium selection

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "dnd-randomizer",
   "title": "Stochastic, Fantastic! - Random Encounter Generator",
   "description": "desc",
-  "version": "0.12",
+  "version": "0.13",
   "system": ["dnd5e"],
   "author": "theripper93, Mouse0270, etriebe",
   "authors": [

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -41,7 +41,7 @@ class SFLocalHelpers {
   
     static async populateItemsFromCompendiums()
     {
-      let filteredCompendiums = game.packs.filter((p) => p.metadata.type === "Item");
+      let filteredCompendiums = game.packs.filter((p) => p.metadata.type === "Item" || p.metadata.entity === "Item");
   
       for (let compendium of filteredCompendiums) {
         if (!compendium)
@@ -84,7 +84,7 @@ class SFLocalHelpers {
   
     static async populateMonstersFromCompendiums()
     {
-      let filteredCompendiums = game.packs.filter((p) => p.metadata.type === "Actor");
+      let filteredCompendiums = game.packs.filter((p) => p.metadata.type === "Actor" || p.metadata.entity === "Actor");
   
       for (let compendium of filteredCompendiums) {
         if (!compendium)

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -207,7 +207,7 @@ class SFLocalHelpers {
         try
         {
           monsterName = randomMonster.name;
-          if (!randomMonster.data || randomMonster.data.data)
+          if (!randomMonster.data || !randomMonster.data.data)
           {
             console.warn(`Monster chosen ${randomMonster.name} didn't have a valid data property.`)
             continue;


### PR DESCRIPTION
I think 9.0 support changed pack.metadata.entity to pack.metadata.type. This will ensure we have support for that too.