### PR TITLE
Filter creatures based on compendium before encounter creation

### DIFF
--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -1,16 +1,11 @@
 class SFLocalHelpers {
-    static allMonsters = {};
+    static allMonsters = [];
     static allSpells = {};
     static spellsByLevel = {};
-    static monstersByEnvironment = {};
     static dictionariesInitialized = false;
     static dictionariesPopulated = false;
   
     static initializeDictionaries() {
-      SFCONSTS.GEN_OPT.environment.forEach((env) => {
-        this.monstersByEnvironment[env] = [];
-      });
-      this.monstersByEnvironment["Any"] = [];
       this.dictionariesInitialized = true;
       this.spellsByLevel["cantrip"] = [];
       this.spellsByLevel["1st level"] = [];
@@ -120,21 +115,20 @@ class SFLocalHelpers {
             }
   
             let environmentArray = environment.split(",");
+            environmentArray = environmentArray.map(e => e.trim());
   
-            if (actorName in this.allMonsters)
+            if (this.allMonsters.filter((m) => m.actor.data.name === actorName).length > 0)
             {
-              console.log(`Already have actor ${actorName} in dictionary`);
+              console.log(`Already have actor ${actorName}, actor id ${actor.data._id} in dictionary`);
               continue;
             }
             let monsterObject = {};
             monsterObject["actor"] = actor;
+            monsterObject["actorid"] = actor.data._id;
             monsterObject["compendiumname"] = compendium.metadata.label;
-            this.allMonsters[actorName] = monsterObject;
-  
-            environmentArray.forEach((e) => {
-              e = e.trim();
-              this.monstersByEnvironment[e].push(monsterObject);
-            });
+            monsterObject["environment"] = environmentArray;
+
+            this.allMonsters.push(monsterObject);
           } 
           catch (error) {
             console.log(error);
@@ -159,24 +153,17 @@ class SFLocalHelpers {
         return !el || el[p.collection] ? true : false;
       });
 
-      for (const monsterObject of this.monstersByEnvironment[environment])
+      for (const monsterObject of this.allMonsters)
       {
         if (filteredCompendiums.filter((c) => c.metadata.label === monsterObject.compendiumname).length === 0) 
         {
           continue;
         }
 
-        filteredMonsters.push(monsterObject.actor);
-      }
-
-      for (const monsterObject of this.monstersByEnvironment["Any"])
-      {
-        if (filteredCompendiums.filter((c) => c.metadata.label === monsterObject.compendiumname).length === 0) 
+        if (monsterObject.environment.indexOf(environment) > -1 || monsterObject.environment.indexOf("Any") > -1)
         {
-          continue;
+          filteredMonsters.push(monsterObject.actor);
         }
-
-        filteredMonsters.push(monsterObject.actor);
       }
 
       return filteredMonsters;

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -126,11 +126,14 @@ class SFLocalHelpers {
               console.log(`Already have actor ${actorName} in dictionary`);
               continue;
             }
-            this.allMonsters[actorName] = actor;
+            let monsterObject = {};
+            monsterObject["actor"] = actor;
+            monsterObject["compendiumname"] = compendium.metadata.label;
+            this.allMonsters[actorName] = monsterObject;
   
             environmentArray.forEach((e) => {
               e = e.trim();
-              this.monstersByEnvironment[e].push(actor);
+              this.monstersByEnvironment[e].push(monsterObject);
             });
           } 
           catch (error) {
@@ -145,15 +148,37 @@ class SFLocalHelpers {
     {
       let environment = params.environment;
       let filteredMonsters = [];
-      for (const monster of this.monstersByEnvironment[environment])
+
+      const constCompFilter = game.settings.get(
+        SFCONSTS.MODULE_NAME,
+        "filterCompendiums"
+      );
+      const filteredCompendiums = Array.from(game.packs).filter((p) => {
+        if (p.documentName !== "Actor") return false;
+        const el = constCompFilter.find((i) => Object.keys(i)[0] == p.collection);
+        return !el || el[p.collection] ? true : false;
+      });
+
+      for (const monsterObject of this.monstersByEnvironment[environment])
       {
-        filteredMonsters.push(monster);
+        if (filteredCompendiums.filter((c) => c.metadata.label === monsterObject.compendiumname).length === 0) 
+        {
+          continue;
+        }
+
+        filteredMonsters.push(monsterObject.actor);
       }
-      for (const monster of this.monstersByEnvironment["Any"])
+
+      for (const monsterObject of this.monstersByEnvironment["Any"])
       {
-        filteredMonsters.push(monster);
+        if (filteredCompendiums.filter((c) => c.metadata.label === monsterObject.compendiumname).length === 0) 
+        {
+          continue;
+        }
+
+        filteredMonsters.push(monsterObject.actor);
       }
-  
+
       return filteredMonsters;
     }
   


### PR DESCRIPTION
This will lead to more encounters being created rather than not, based on too many creatures being filtered out from the full list in the world. 

Also refactor some logic to change to use arrays and .filter logic instead of dictionaries with keys/hashes based on environment. This should pave the way for some filtering based on creature type too. 