### PR TITLE
Use player characters in Foundry for deciding what level and how many PCs to create an encounter for

### DIFF
--- a/scripts/compendium.js
+++ b/scripts/compendium.js
@@ -59,7 +59,7 @@ class SFCompendiumSorter extends FormApplication {
 		
 		const savedPlayerSettings = game.settings.get(
 			SFCONSTS.MODULE_NAME,
-			"pcsToCreateEncountersFor"
+			"playerCharactersToCreateEncountersFor"
 		  );
 		
 		for (let player of playerCharacters) {
@@ -116,14 +116,13 @@ class SFCompendiumSorter extends FormApplication {
 	async activateListeners(html) {
 		this.populatePlayerCharacters();
 		this.populateCompendiums(["Actor","Item"]);
-		// await SFLocalHelpers.populateObjectsFromCompendiums();
 		this.populateCreatureTypes();
 	}
 
 	async close(options) { 
 		await this.saveCompendiumSetting();
 		await this.saveMonsterTypeSetting();
-
+		await this.savePlayerCharacterSetting();
 		// Default Close
 		return await super.close(options);
 	}
@@ -179,7 +178,7 @@ class SFCompendiumSorter extends FormApplication {
 		});
 		console.log(playerCharacterSettings)
 		
-		await game.settings.set(SFCONSTS.MODULE_NAME, 'pcsToCreateEncountersFor',playerCharacterSettings);
+		await game.settings.set(SFCONSTS.MODULE_NAME, 'playerCharactersToCreateEncountersFor',playerCharacterSettings);
 	}
 
 	async _updateObject(event, formData) {

--- a/scripts/compendium.js
+++ b/scripts/compendium.js
@@ -67,22 +67,19 @@ class SFCompendiumSorter extends FormApplication {
 			const el = savedPlayerSettings.find(i => Object.keys(i)[0] === playerName);
 			let playerClasses = player.classes;
 			let playerClassList = Object.keys(playerClasses);
-			let playerClassDescriptionList = [];
+			let playerClassSpans = [];
 			for (let i = 0; i < playerClassList.length; i++)
 			{
 				let currentClassName = playerClassList[i];
 				let currentClassNameCasedCorrect = currentClassName.charAt(0).toUpperCase() + currentClassName.slice(1);
 				let currentClass = playerClasses[currentClassName];
 				let currentClassLevel = currentClass.data.data.levels;
-				let currentClassDescription = `${currentClassNameCasedCorrect}: Level ${currentClassLevel}`;
-				console.log(currentClassDescription);
-				playerClassDescriptionList.push(currentClassDescription);
+				let currentClassSpan = `<span class="player-character-info" data-type="${currentClassName}">${currentClassNameCasedCorrect}: Level ${currentClassLevel}</span>`;
+				playerClassSpans.push(currentClassSpan);
 			}
-			let fullDescription = playerClassDescriptionList.join(", ");
-			console.log(playerName);
 			$ul.append(`<li class="playerCharacterLi">
 				<input type="checkbox" name="${playerName}" ${!el || el[playerName] ? "checked" : ""}>
-				<span class="player-character-info">${fullDescription}</span>
+				${playerClassSpans.join("")}
 				<span class="player-character">${playerName}</span>
 			</li>`)
 		}

--- a/scripts/compendium.js
+++ b/scripts/compendium.js
@@ -52,6 +52,46 @@ class SFCompendiumSorter extends FormApplication {
 		});
 	}
 
+	populatePlayerCharacters() {
+		const html = this.element
+		let $ul = html.find('ul#player_filter').first();
+		let playerCharacters = game.actors.filter(a=>a.hasPlayerOwner === true);
+		
+		const savedPlayerSettings = game.settings.get(
+			SFCONSTS.MODULE_NAME,
+			"pcsToCreateEncountersFor"
+		  );
+		
+		for (let player of playerCharacters) {
+			let playerName = player.name;
+			const el = savedPlayerSettings.find(i => Object.keys(i)[0] === playerName);
+			let playerClasses = player.classes;
+			let playerClassList = Object.keys(playerClasses);
+			let playerClassDescriptionList = [];
+			for (let i = 0; i < playerClassList.length; i++)
+			{
+				let currentClassName = playerClassList[i];
+				let currentClassNameCasedCorrect = currentClassName.charAt(0).toUpperCase() + currentClassName.slice(1);
+				let currentClass = playerClasses[currentClassName];
+				let currentClassLevel = currentClass.data.data.levels;
+				let currentClassDescription = `${currentClassNameCasedCorrect}: Level ${currentClassLevel}`;
+				console.log(currentClassDescription);
+				playerClassDescriptionList.push(currentClassDescription);
+			}
+			let fullDescription = playerClassDescriptionList.join(", ");
+			console.log(playerName);
+			$ul.append(`<li class="playerCharacterLi">
+				<input type="checkbox" name="${playerName}" ${!el || el[playerName] ? "checked" : ""}>
+				<span class="player-character-info">${fullDescription}</span>
+				<span class="player-character">${playerName}</span>
+			</li>`)
+		}
+
+		sortable('#SFCompendiumSorter .sortable-compendiums', {
+			forcePlaceholderSize: true
+		});
+	}
+
 	populateCreatureTypes() {
 		const html = this.element
 		let $ul = html.find('ul#creature_filter').first();
@@ -77,6 +117,7 @@ class SFCompendiumSorter extends FormApplication {
 	}
 	
 	async activateListeners(html) {
+		this.populatePlayerCharacters();
 		this.populateCompendiums(["Actor","Item"]);
 		// await SFLocalHelpers.populateObjectsFromCompendiums();
 		this.populateCreatureTypes();
@@ -124,6 +165,24 @@ class SFCompendiumSorter extends FormApplication {
 		console.log(filterMonsterSettings)
 		
 		await game.settings.set(SFCONSTS.MODULE_NAME, 'filterMonsterTypes',filterMonsterSettings);
+	}
+
+	async savePlayerCharacterSetting()
+	{
+		const html = this.element;
+		let $ul = html.find('ul#player_filter').first();
+		let playerCharacterSettings = [];
+
+		$ul.find('li.playerCharacterLi').each((index, item) => {
+			let $element = $(item).find('input');
+			let setting = {};
+			setting[$element.attr('name')] = $element.is(':checked');
+
+			playerCharacterSettings.push(setting);
+		});
+		console.log(playerCharacterSettings)
+		
+		await game.settings.set(SFCONSTS.MODULE_NAME, 'pcsToCreateEncountersFor',playerCharacterSettings);
 	}
 
 	async _updateObject(event, formData) {

--- a/scripts/compendium.js
+++ b/scripts/compendium.js
@@ -55,6 +55,14 @@ class SFCompendiumSorter extends FormApplication {
 	populatePlayerCharacters() {
 		const html = this.element
 		let $ul = html.find('ul#player_filter').first();
+		let useLocalPCs = game.settings.get(SFCONSTS.MODULE_NAME, 'usePlayerOwnedCharactersForGeneration');
+
+		if (!useLocalPCs)
+		{
+			$ul.append("Filtering not available because setting wasn't specified to use player-owned actors for generation.");
+			return;
+		}
+
 		let playerCharacters = game.actors.filter(a=>a.hasPlayerOwner === true);
 		
 		const savedPlayerSettings = game.settings.get(

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,4 +1,5 @@
 Hooks.once("init", async function () {
+	const debouncedReload = foundry.utils.debounce(function () { window.location.reload(); }, 100);
   game.settings.register(SFCONSTS.MODULE_NAME, "actorFolder", {
     name: "Actor Folder Name",
     hint: "Sets the folder name that the actors will be added to when imported",
@@ -30,6 +31,7 @@ Hooks.once("init", async function () {
     config: true,
     type: Boolean,
     default: true,
+    onChange:debouncedReload,
   });
   game.settings.register(SFCONSTS.MODULE_NAME, 'favoritedEncounters', {
     scope: "world",

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -43,6 +43,13 @@ Hooks.once("init", async function () {
     type: Object,
     default: [],
   })
+  
+  game.settings.register(SFCONSTS.MODULE_NAME, 'pcsToCreateEncountersFor', {
+    scope: "world",
+    config: false,
+    type: Object,
+    default: [],
+  })
   game.settings.register(SFCONSTS.MODULE_NAME, 'secretEncounterIcon', {
     scope: "world",
     config: false,

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -44,7 +44,7 @@ Hooks.once("init", async function () {
     default: [],
   })
   
-  game.settings.register(SFCONSTS.MODULE_NAME, 'pcsToCreateEncountersFor', {
+  game.settings.register(SFCONSTS.MODULE_NAME, 'playerCharactersToCreateEncountersFor', {
     scope: "world",
     config: false,
     type: Object,

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -23,39 +23,47 @@ Hooks.once("init", async function () {
     type: Boolean,
     default: true,
   });
+  game.settings.register(SFCONSTS.MODULE_NAME, "usePlayerOwnedCharactersForGeneration", {
+    name: "Use Player-owned Actors in-game to generate encounters.",
+    hint: "If checked, we will find all player-owned characters and use that to generate encounters. Select/deselect individuals in Filter dialog.",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true,
+  });
   game.settings.register(SFCONSTS.MODULE_NAME, 'favoritedEncounters', {
     scope: "world",
     config: false,
     type: Object,
     default: {},
-  })
+  });
   
   game.settings.register(SFCONSTS.MODULE_NAME, 'filterCompendiums', {
     scope: "world",
     config: false,
     type: Object,
     default: [],
-  })
+  });
   
   game.settings.register(SFCONSTS.MODULE_NAME, 'filterMonsterTypes', {
     scope: "world",
     config: false,
     type: Object,
     default: [],
-  })
+  });
   
   game.settings.register(SFCONSTS.MODULE_NAME, 'playerCharactersToCreateEncountersFor', {
     scope: "world",
     config: false,
     type: Object,
     default: [],
-  })
+  });
   game.settings.register(SFCONSTS.MODULE_NAME, 'secretEncounterIcon', {
     scope: "world",
     config: false,
     type: Boolean,
     default: false,
-  })
+  });
 });
 
 Hooks.on("renderSidebarTab",(settings) => {

--- a/scripts/dialog.js
+++ b/scripts/dialog.js
@@ -5,11 +5,13 @@ class SFDialog extends FormApplication {
 	}
 
 	static get defaultOptions() {
+		let useLocalPCs = game.settings.get(SFCONSTS.MODULE_NAME, 'usePlayerOwnedCharactersForGeneration');
+		let dialogTemplate = useLocalPCs ? `modules/dnd-randomizer/templates/usePCsDialog.hbs` : `modules/dnd-randomizer/templates/dialog.hbs`;
 		return { 
 			...super.defaultOptions,
 			title: game.i18n.localize('SF.dialog.title'),
 			id: "SFDialog",
-			template: `modules/dnd-randomizer/templates/dialog.hbs`,
+			template: dialogTemplate,
 			resizable: true,
 			width: window.innerWidth > 700 ? 700 : window.innerWidth - 100,
 			height: window.innerHeight > 800 ? 800 : window.innerHeight - 100
@@ -152,13 +154,27 @@ class SFDialog extends FormApplication {
 
 			$button.prop('disabled', true).addClass('disabled');
 			$button.find('i.fas').removeClass('fa-dice').addClass('fa-spinner fa-spin');
-			const params = {
-				loot_type: html.find('#lootType select[name="lootType"]').val(),
-				numberOfPlayers: html.find('#numberOfPlayers select[name="numberOfPlayers"]').val(),
-				averageLevelOfPlayers: html.find('#averageLevelOfPlayers select[name="averageLevelOfPlayers"]').val(),
-				environment: html.find('#environmentSelector select[name="environmentSelector"]').val()
+			let numberOfPlayers = 0;
+			let averageLevelOfPlayers = 0;
+			let useLocalPCs = game.settings.get(SFCONSTS.MODULE_NAME, 'usePlayerOwnedCharactersForGeneration');
+			if (useLocalPCs)
+			{
+				let activePlayerInfo = SFLocalHelpers.getActivePlayersCountAndLevels();
+				numberOfPlayers = activePlayerInfo["numberofplayers"];
+				averageLevelOfPlayers = activePlayerInfo["averageplayerlevel"];
+			}
+			else
+			{
+				numberOfPlayers = html.find('#numberOfPlayers select[name="numberOfPlayers"]').val();
+				averageLevelOfPlayers = html.find('#averageLevelOfPlayers select[name="averageLevelOfPlayers"]').val();
 			}
 			
+			const params = {
+				loot_type: html.find('#lootType select[name="lootType"]').val(),
+				numberOfPlayers: numberOfPlayers,
+				averageLevelOfPlayers: averageLevelOfPlayers,
+				environment: html.find('#environmentSelector select[name="environmentSelector"]').val()
+			}
 
 			if (SFHelpers.useLocalEncounterGenerator())
 			{

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -164,6 +164,55 @@ class SFLocalHelpers {
       {
         characterTraits["damagevulnerabilities"] = actor.data.data.traits.dv.value;
       }
+
+      let actorSpells = actor.data.data.spells;
+      let maxSpellLevel = 0;
+      for (var i = 1; i <= 9; i++)
+      {
+        let currentSpellLevelObject = eval("actorsSpells.spell" + i);
+        if (currentSpellLevelObject.max > 0)
+        {
+          characterTraits["spellcaster"] = true;
+          maxSpellLevel = i;
+        }
+      }
+
+      // deal with pact magic
+      if (actorSpells.pact.max > 0)
+      {
+        characterTraits["spellcaster"] = true;
+        let pactLevel = actorSpells.pact.level;
+        if (maxSpellLevel > pactLevel)
+        {
+          maxSpellLevel = pactLevel;
+        }
+      }
+      if (maxSpellLevel > 0)
+      {
+        characterTraits["maxspelllevel"] = maxSpellLevel;
+        characterTraits["spelldamagetypelist"] = spellList.map(s => s.data.data.damage.parts).filter(p => p.length > 0).map(z=> z[0][1]).filter(t => t != "");
+      }
+
+      if (actor.data.data.resources.lair.value)
+      {
+        characterTraits["lairactions"] = true;
+      }
+
+      if (actor.data.data.resources.legact.max > 0)
+      {
+        characterTraits["legendaryactions"] = true;
+      }
+
+      if (actor.data.data.resources.legres.max > 0)
+      {
+        characterTraits["legendaryresistances"] = true;
+      }
+
+      let spellList = actor.items.filter(i => i.type === "spell");
+      if (spellList.filter(s => s.hasAreaTarget && s.hasDamage && s.name.toLowerCase() != "sleep").length > 0)
+      {
+        characterTraits["hasAOESpell"] = true;
+      }
     }
   
     static async filterMonstersFromCompendiums(params)

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -33,6 +33,11 @@ class SFLocalHelpers {
         this.dictionariesPopulated = true;
       }
     }
+
+    static async populateCurrentActors() {
+      let pcs = game.actors.filter(a=>a.type === "character");
+      let pcs2 = game.actors.filter(a=>a.hasPlayerOwner === true);
+    }
   
     static async populateItemsFromCompendiums()
     {
@@ -135,6 +140,28 @@ class SFLocalHelpers {
             console.log(`Actor id ${entry._id} failed to get added.`);
           }
         }
+      }
+    }
+
+    static getActorTraits(actor)
+    {
+      let characterTraits = {};
+
+      if (actor.data.data.traits.ci.value.length > 0)
+      {
+        characterTraits["conditionimmunities"] = actor.data.data.traits.ci.value;
+      }
+      if (actor.data.data.traits.di.value.length > 0)
+      {
+        characterTraits["damageimmunities"] = actor.data.data.traits.di.value;
+      }
+      if (actor.data.data.traits.dr.value.length > 0)
+      {
+        characterTraits["damageresistances"] = actor.data.data.traits.dr.value;
+      }
+      if (actor.data.data.traits.dv.value.length > 0)
+      {
+        characterTraits["damagevulnerabilities"] = actor.data.data.traits.dv.value;
       }
     }
   

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -34,6 +34,44 @@ class SFLocalHelpers {
       }
     }
 
+    static getActivePlayersCountAndLevels() {
+      let playerCharacters = game.actors.filter(a=>a.hasPlayerOwner === true);
+      const savedPlayerSettings = game.settings.get(
+        SFCONSTS.MODULE_NAME,
+        "playerCharactersToCreateEncountersFor"
+        );
+      let levelList = [];
+
+      for (let player of playerCharacters) {
+        let playerName = player.name;
+        const el = savedPlayerSettings.find(i => Object.keys(i)[0] === playerName);
+        if (el[playerName] === false)
+        {
+          continue;
+        }
+
+        let playerClasses = player.classes;
+        let playerClassList = Object.keys(playerClasses);
+        let totalLevelCount = 0;
+        for (let i = 0; i < playerClassList.length; i++)
+        {
+          let currentClassLevel = playerClasses[playerClassList[i]].data.data.levels;
+          totalLevelCount += currentClassLevel;
+        }
+
+        levelList.push(totalLevelCount);
+      }
+      var total = 0;
+      for(var i = 0; i < levelList.length; i++) {
+          total += levelList[i];
+      }
+      var avg = Math.floor(total / levelList.length);
+      let resultObject = {};
+      resultObject["numberofplayers"] = levelList.length;
+      resultObject["averageplayerlevel"] = avg;
+      return resultObject;
+    }
+
     static async populateCurrentActors() {
       let playerCharacters = game.actors.filter(a=>a.hasPlayerOwner === true);
     }

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -35,8 +35,7 @@ class SFLocalHelpers {
     }
 
     static async populateCurrentActors() {
-      let pcs = game.actors.filter(a=>a.type === "character");
-      let pcs2 = game.actors.filter(a=>a.hasPlayerOwner === true);
+      let playerCharacters = game.actors.filter(a=>a.hasPlayerOwner === true);
     }
   
     static async populateItemsFromCompendiums()

--- a/styles/encounterGenerator.css
+++ b/styles/encounterGenerator.css
@@ -514,3 +514,13 @@
     font-size: 0.7rem;
     opacity: 0.8;
 }
+
+#SFCompendiumSorter form ul li span.player-character-info {
+    background-color: var(--palette-primary, #116b86);
+    color: var(--palette-primary-contrast-text, #fff);
+    order: 2;
+    margin-left: auto;
+    font-size: 0.7rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+}

--- a/styles/encounterGenerator.css
+++ b/styles/encounterGenerator.css
@@ -524,3 +524,59 @@
     padding: 0.25rem 0.5rem;
     border-radius: 0.25rem;
 }
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="artificer"] {
+    background-color: var(--palette-primary, #7D673C);
+}
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="barbarian"] {
+    background-color: var(--palette-primary, #D1775F);
+}
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="blood-hunter"] {
+    background-color: var(--palette-primary, #5A0505);
+}
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="bard"] {
+    background-color: var(--palette-primary, #B087B1);
+}
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="cleric"] {
+    background-color: var(--palette-primary, #8E8F91);
+}
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="druid"] {
+    background-color: var(--palette-primary, #8A9554);
+}
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="fighter"] {
+    background-color: var(--palette-primary, #715348);
+}
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="monk"] {
+    background-color: var(--palette-primary, #81C1DA);
+}
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="paladin"] {
+    background-color: var(--palette-primary, #BCA863);
+}
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="ranger"] {
+    background-color: var(--palette-primary, #48795B);
+}
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="rogue"] {
+    background-color: var(--palette-primary, #494A44);
+}
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="sorcerer"] {
+    background-color: var(--palette-primary, #C4545A);
+}
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="warlock"] {
+    background-color: var(--palette-primary, #8050B1);
+}
+
+#SFCompendiumSorter form ul li span.player-character-info[data-type="wizard"] {
+    background-color: var(--palette-primary, #3E6EBE);
+}

--- a/templates/compendium.hbs
+++ b/templates/compendium.hbs
@@ -1,4 +1,8 @@
 <form>
+	<h3 class="flexrow">Players in encounters</h3><hr/>
+	<ul class="sortable-compendiums" id="player_filter">
+
+	</ul>
 	<h3 class="flexrow">Sort & Filter Compendiums</h3><hr/>
 	<ul class="sortable-compendiums" id="compendium_filter">
 

--- a/templates/usePCsDialog.hbs
+++ b/templates/usePCsDialog.hbs
@@ -1,0 +1,44 @@
+<form>
+	<div class="form-controls">
+		<div class="form-groups">
+			I'm looking for an encounter in a
+			<span id="environmentSelector" class="input-container">
+				<span class="placeholder">{{environments.[0]}}</span>
+				<span class="input selectbox">
+					<select class="fancy-select hidden" name="environmentSelector">
+					{{#each environments}}
+						<option value="{{this}}">{{this}}</option>
+					{{/each}}
+					</select>
+				</span>
+			</span>
+			environment. They will find 
+			<span id="lootType" class="input-container">
+				<span class="placeholder">Treasure Hoard</span>
+				<span class="input selectbox">
+					<select class="fancy-select hidden" name="lootType">
+						<option value="Individual Treasure">Individual Treasure</option>
+						<option value="Treasure Hoard" selected>Treasure Hoard</option>
+					</select>
+				</span>
+			</span>
+			.
+		</div>
+		<button id="generate-remote-encounters-button" class="generate-encounters"><i class="fas fa-dice"></i> Generate Encounters</button>
+	</div>
+	<div class="form-encounters">
+		<div class="filter-controller">
+			<select>
+				<option value="all">All</option>
+				<option value="favorited">Favorited</option>
+			</select>
+			<input id="search-box" type="text" spellcheck="false" placeholder="Start typing to filter Encounters">
+			<button title="Clear search field" id="clear-button"><i class="fas fa-times"></i></button>
+			<button class="filter-compendiums" id="filter-button"><i class="fas fa-filter"></i></button>
+			<button class="license-and-credits" id="license-and-credits" title="licensing & Credits"><i class="fas fa-info-circle"></i></button>
+		</div>
+		<div class="encounters">
+			<ul></ul>
+		</div>
+	</div>
+</form>


### PR DESCRIPTION
1. Add a setting and functionality to support creating the encounter based on the players who have owners
2. Add a list of PCs and their current class/level to the filter page so users can select/deselect players who are

When the setting is active, the text change to not specify # of players & average level and just ask for the environment & treasure type.

![image](https://user-images.githubusercontent.com/7503160/147627457-58236fcc-40ec-4f3d-8348-84533ff31975.png)

Add a list of players to the filter so some can be deselected if someone isn't available for a session. 

![image](https://user-images.githubusercontent.com/7503160/147627507-08a7e812-b715-42f2-8476-4ac049c51475.png)

