### PR TITLE
Prevent a null reference error on getting player character level count

### DIFF
--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -46,7 +46,7 @@ class SFLocalHelpers {
       for (let player of playerCharacters) {
         let playerName = player.name;
         const el = savedPlayerSettings.find(i => Object.keys(i)[0] === playerName);
-        if (el[playerName] === false)
+        if (el && el[playerName] === false)
         {
           continue;
         }


### PR DESCRIPTION
If a player hasn't clicked the filter this error could appear. 