### PR TITLE
Add setting to clear existing encounters upon generation of new ones

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -33,6 +33,14 @@ Hooks.once("init", async function () {
     default: true,
     onChange:debouncedReload,
   });
+  game.settings.register(SFCONSTS.MODULE_NAME, "clearOldEncountersOnGeneration", {
+    name: "Clear existing encounters when generating new ones (besides favorited encounters).",
+    hint: "If checked, we will clear the existing encounters when we generate new ones. Else these will be populated below the current list.",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true,
+  });
   game.settings.register(SFCONSTS.MODULE_NAME, 'favoritedEncounters', {
     scope: "world",
     config: false,

--- a/scripts/dialog.js
+++ b/scripts/dialog.js
@@ -160,6 +160,19 @@ class SFDialog extends FormApplication {
 
 		html.find('button#generate-remote-encounters-button').on('click', async (event) => {
 			event.preventDefault();
+			let clearOldEncounters = game.settings.get(SFCONSTS.MODULE_NAME, 'clearOldEncountersOnGeneration');
+			if (clearOldEncounters)
+			{
+				const $li = html.find('.form-encounters li');
+				for (var i = 0; i < $li.length; i++)
+				{
+					let currentEncounter = $li[i];
+					if (currentEncounter.classList.contains("is-favorited-false"))
+					{
+						currentEncounter.remove();
+					}
+				}
+			}
 			const $button = $(event.currentTarget);
 
 			$button.prop('disabled', true).addClass('disabled');
@@ -231,6 +244,11 @@ class SFDialog extends FormApplication {
 		html.find('button#filter-button').on('click', (event) => {
 			event.preventDefault();
 			new SFCompendiumSorter().render(true);
+		});
+
+		html.find('button#clear-encounters-button').on('click', function(event) {
+			event.preventDefault();
+			// html.find('input#search-box').val('').trigger('change');
 		});
 
 		html.find('button#license-and-credits').on('click', (event) => {


### PR DESCRIPTION
Currently we'll just populate and fill over and over, which means scrolling down even more. 