### PR TITLE
Fix a bug where if a character had no class levels they'd break encounter generation if average party level was < 1

### DIFF
--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -60,6 +60,11 @@ class SFLocalHelpers {
           totalLevelCount += currentClassLevel;
         }
 
+        if (totalLevelCount === 0)
+        {
+          console.log(`Player ${player.name} has no class level so skipping them.`);
+          continue;
+        }
         levelList.push(totalLevelCount);
       }
       let total = 0;


### PR DESCRIPTION
This would lead to an invalid encounter target for XP and loop endlessly. 