### PR TITLE
Add encounter generation based on formula (e.g. 1 BBEG, BBEG + minions)

### DIFF
--- a/scripts/dialog.js
+++ b/scripts/dialog.js
@@ -397,7 +397,7 @@ class SFDialog extends FormApplication {
 		$('#averageLevelOfPlayers .placeholder').text(charData.level);
 		$('#averageLevelOfPlayers select').val(charData.level);
 		$(`#averageLevelOfPlayers .newOptions .newOption[data-value="${charData.level}"]`).addClass('active selected');
-		$(`#lootType .newOptions .newOption[data-value="Treasure Hoard"]`).addClass('active selected');
+		$(`#lootType .newOptions .newOption[data-value="Treasure horde"]`).addClass('active selected');
 	}
 
 	async _updateObject(event, formData) {

--- a/scripts/dialog.js
+++ b/scripts/dialog.js
@@ -397,7 +397,7 @@ class SFDialog extends FormApplication {
 		$('#averageLevelOfPlayers .placeholder').text(charData.level);
 		$('#averageLevelOfPlayers select').val(charData.level);
 		$(`#averageLevelOfPlayers .newOptions .newOption[data-value="${charData.level}"]`).addClass('active selected');
-		$(`#lootType .newOptions .newOption[data-value="Treasure horde"]`).addClass('active selected');
+		$(`#lootType .newOptions .newOption[data-value="Treasure Horde"]`).addClass('active selected');
 	}
 
 	async _updateObject(event, formData) {

--- a/scripts/dialog.js
+++ b/scripts/dialog.js
@@ -194,6 +194,7 @@ class SFDialog extends FormApplication {
 			
 			const params = {
 				loot_type: html.find('#lootType select[name="lootType"]').val(),
+				encounterType: html.find('#encounterType select[name="encounterType"]').val(),
 				numberOfPlayers: numberOfPlayers,
 				averageLevelOfPlayers: averageLevelOfPlayers,
 				environment: html.find('#environmentSelector select[name="environmentSelector"]').val()

--- a/scripts/localconst.js
+++ b/scripts/localconst.js
@@ -91,7 +91,7 @@ const SFLOCALCONSTS = {
         "16-55":    ["", "", "", "1d6 x 1000", "1d6 x 100"],
         "56-100":    ["", "", "", "1d6 x 1000", "2d6 x 100"],
     },
-    ENCOUNTER_TREASURE_horde_CR4: {
+    ENCOUNTER_TREASURE_HORDE_CR4: {
         "01-06" :   ["", ""],
         "07-16" :   ["2d6 10 gp gems",	""],
         "17-26" :   ["2d4 25 gp art objects", ""],
@@ -110,7 +110,7 @@ const SFLOCALCONSTS = {
         "98-99" :   ["2d4 25 gp art objects",	"Roll 1d1 on Magic Item Table G."],
         "100"   :   ["2d6 50 gp gems",	        "Roll 1d1 on Magic Item Table G."],
     },
-    ENCOUNTER_TREASURE_horde_CR10: {
+    ENCOUNTER_TREASURE_HORDE_CR10: {
         "01-04"	:   ["", ""],
         "05-10"	:   ["2d4 25 gp art objects",	""],
         "11-16"	:   ["3d6 50 gp gems",	""],
@@ -141,7 +141,7 @@ const SFLOCALCONSTS = {
         "99"	:   ["3d6 100 gp gems",	        "Roll 1d1 on Magic Item Table H."],
         "100"	:   ["2d4 250 gp art objects",	"Roll 1d1 on Magic Item Table H."],
     },
-    ENCOUNTER_TREASURE_horde_CR16: {
+    ENCOUNTER_TREASURE_HORDE_CR16: {
         "01-03" :	["",	""],
         "04-06" :	["2d4 250 gp art objects",	""],
         "07-09" :	["2d4 750 gp art objects",	""],
@@ -176,7 +176,7 @@ const SFLOCALCONSTS = {
         "97-98" :	["3d6 500 gp gems",	        "Roll 1d1 on Magic Item Table I."],
         "99-100" :	["3d6 1,000 gp gems",	    "Roll 1d1 on Magic Item Table I."],
     },
-    ENCOUNTER_TREASURE_horde_CR17_PLUS: {
+    ENCOUNTER_TREASURE_HORDE_CR17_PLUS: {
         "01-04"	:   ["", ""],
         "05-10"	:   ["2d4 25 gp art objects",	""],
         "11-16"	:   ["3d6 50 gp gems",	""],

--- a/scripts/localconst.js
+++ b/scripts/localconst.js
@@ -91,7 +91,7 @@ const SFLOCALCONSTS = {
         "16-55":    ["", "", "", "1d6 x 1000", "1d6 x 100"],
         "56-100":    ["", "", "", "1d6 x 1000", "2d6 x 100"],
     },
-    ENCOUNTER_TREASURE_HOARD_CR4: {
+    ENCOUNTER_TREASURE_horde_CR4: {
         "01-06" :   ["", ""],
         "07-16" :   ["2d6 10 gp gems",	""],
         "17-26" :   ["2d4 25 gp art objects", ""],
@@ -110,7 +110,7 @@ const SFLOCALCONSTS = {
         "98-99" :   ["2d4 25 gp art objects",	"Roll 1d1 on Magic Item Table G."],
         "100"   :   ["2d6 50 gp gems",	        "Roll 1d1 on Magic Item Table G."],
     },
-    ENCOUNTER_TREASURE_HOARD_CR10: {
+    ENCOUNTER_TREASURE_horde_CR10: {
         "01-04"	:   ["", ""],
         "05-10"	:   ["2d4 25 gp art objects",	""],
         "11-16"	:   ["3d6 50 gp gems",	""],
@@ -141,7 +141,7 @@ const SFLOCALCONSTS = {
         "99"	:   ["3d6 100 gp gems",	        "Roll 1d1 on Magic Item Table H."],
         "100"	:   ["2d4 250 gp art objects",	"Roll 1d1 on Magic Item Table H."],
     },
-    ENCOUNTER_TREASURE_HOARD_CR16: {
+    ENCOUNTER_TREASURE_horde_CR16: {
         "01-03" :	["",	""],
         "04-06" :	["2d4 250 gp art objects",	""],
         "07-09" :	["2d4 750 gp art objects",	""],
@@ -176,7 +176,7 @@ const SFLOCALCONSTS = {
         "97-98" :	["3d6 500 gp gems",	        "Roll 1d1 on Magic Item Table I."],
         "99-100" :	["3d6 1,000 gp gems",	    "Roll 1d1 on Magic Item Table I."],
     },
-    ENCOUNTER_TREASURE_HOARD_CR17_PLUS: {
+    ENCOUNTER_TREASURE_horde_CR17_PLUS: {
         "01-04"	:   ["", ""],
         "05-10"	:   ["2d4 25 gp art objects",	""],
         "11-16"	:   ["3d6 50 gp gems",	""],
@@ -734,7 +734,8 @@ const SFLOCALCONSTS = {
         "Single BBEG": ["1:1*x"],
         "BBEG + 2 Minions": ["1:0.3*x","2:0.1*x"],
         "2 Semi-BBEG": ["2:0.3333*x"],
-        "Monster Hoard": ["6:0.08333*x"],
+        "BBEG + Monster horde": ["1:0.3*x","5:0.04*x"],
+        "Monster horde": ["6:0.08333*x"],
         "Random": ["*"],
     }
 }

--- a/scripts/localconst.js
+++ b/scripts/localconst.js
@@ -730,7 +730,7 @@ const SFLOCALCONSTS = {
         "12": "Armor, +3 plate",
     },
     ENCOUNTER_TYPE_DESCRIPTIONS: {
-        // Formula format ["1:.3*x","2:.1*x"] - This will create an encounter 
+        // Formula format ["1:.3*x","2:.1*x"] - This will create an encounter with 1 creature that is 30% of target XP and 2 creatures that are 10% target XP
         "Single BBEG": ["1:1*x"],
         "BBEG + 2 Minions": ["1:0.3*x","2:0.1*x"],
         "2 Semi-BBEG": ["2:0.3333*x"],

--- a/scripts/localconst.js
+++ b/scripts/localconst.js
@@ -728,5 +728,13 @@ const SFLOCALCONSTS = {
         "9-10": "Armor, +3 splint",
         "11": "Armor, +3 half plate",
         "12": "Armor, +3 plate",
+    },
+    ENCOUNTER_TYPE_DESCRIPTIONS: {
+        // Formula format ["1:.3*x","2:.1*x"] - This will create an encounter 
+        "Single BBEG": ["1:1*x"],
+        "BBEG + 2 Minions": ["1:0.3*x","2:0.1*x"],
+        "2 Semi-BBEG": ["2:0.3333*x"],
+        "Monster Hoard": ["6:0.08333*x"],
+        "Random": ["*"],
     }
 }

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -801,19 +801,19 @@ class SFLocalHelpers {
             let individualTreasureRowContents;
             if (monsterCR <= 4)
             {
-              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR4, d100Roll);
+              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasureHordeTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR4, d100Roll);
             }
             else if (monsterCR <= 10)
             {
-              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR10, d100Roll);
+              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasureHordeTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR10, d100Roll);
             }
             else if (monsterCR <= 16)
             {
-              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR16, d100Roll);
+              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasureHordeTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR16, d100Roll);
             }
             else
             {
-              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR17_PLUS, d100Roll);
+              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasureHordeTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR17_PLUS, d100Roll);
             }
   
             currencyResultObject["cp"] += SFLocalHelpers.getCoinsResultFromRollTable(individualTreasureRowContents[0]);
@@ -886,7 +886,7 @@ class SFLocalHelpers {
           currencyResultObject["cp"] += this.getRollResult("6d6") * 100;
           currencyResultObject["sp"] += this.getRollResult("3d6") * 100;
           currencyResultObject["gp"] += this.getRollResult("2d6") * 10;
-          treasureHordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HORDE_CR4, d100Roll);
+          treasureHordeRowContents = SFLocalHelpers.getResultFromTreasureHordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HORDE_CR4, d100Roll);
         }
         else if (maximumCRFromGroup <= 10)
         {
@@ -894,19 +894,19 @@ class SFLocalHelpers {
           currencyResultObject["sp"] += this.getRollResult("2d6") * 1000;
           currencyResultObject["gp"] += this.getRollResult("6d6") * 100;
           currencyResultObject["pp"] += this.getRollResult("3d6") * 10;
-          treasureHordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HORDE_CR10, d100Roll);
+          treasureHordeRowContents = SFLocalHelpers.getResultFromTreasureHordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HORDE_CR10, d100Roll);
         }
         else if (maximumCRFromGroup <= 16)
         {
           currencyResultObject["gp"] += this.getRollResult("4d6") * 1000;
           currencyResultObject["pp"] += this.getRollResult("5d6") * 100;
-          treasureHordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HORDE_CR16, d100Roll);
+          treasureHordeRowContents = SFLocalHelpers.getResultFromTreasureHordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HORDE_CR16, d100Roll);
         }
         else
         {
           currencyResultObject["gp"] += this.getRollResult("12d6") * 1000;
           currencyResultObject["pp"] += this.getRollResult("8d6") * 1000;
-          treasureHordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HORDE_CR17_PLUS, d100Roll);
+          treasureHordeRowContents = SFLocalHelpers.getResultFromTreasureHordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HORDE_CR17_PLUS, d100Roll);
         }
   
         try
@@ -929,7 +929,7 @@ class SFLocalHelpers {
       return lootResultObject;
     }
   
-    static getResultFromTreasurehordeTable(rollTable, rollResult)
+    static getResultFromTreasureHordeTable(rollTable, rollResult)
     {
       let rowSelected;
       for (let key in rollTable)
@@ -1081,7 +1081,7 @@ class SFLocalHelpers {
       }
   
       let randomItemNumber = Math.floor(Math.random() * maxNumberToRollFor) + 1;
-      return SFLocalHelpers.getResultFromTreasurehordeTable(rollTable, randomItemNumber);
+      return SFLocalHelpers.getResultFromTreasureHordeTable(rollTable, randomItemNumber);
     }
   
     static getMagicItemTable(regexMatchResultGroups)

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -759,7 +759,7 @@ class SFLocalHelpers {
       }
       else
       {
-        generatedLoot = SFLocalHelpers.getTreasurehordeForEncounter(currentEncounter);
+        generatedLoot = SFLocalHelpers.getTreasureHordeForEncounter(currentEncounter);
       }
   
       return generatedLoot;
@@ -846,7 +846,7 @@ class SFLocalHelpers {
       return totalCoins;
     }
   
-    static getTreasurehordeForEncounter(currentEncounter)
+    static getTreasureHordeForEncounter(currentEncounter)
     {
       let creatures = currentEncounter["creatures"];
       let lootResultObject = {};
@@ -880,13 +880,13 @@ class SFLocalHelpers {
   
         let d100Roll = this.getRollResult("1d100");
   
-        let treasurehordeRowContents;
+        let treasureHordeRowContents;
         if (maximumCRFromGroup <= 4)
         {
           currencyResultObject["cp"] += this.getRollResult("6d6") * 100;
           currencyResultObject["sp"] += this.getRollResult("3d6") * 100;
           currencyResultObject["gp"] += this.getRollResult("2d6") * 10;
-          treasurehordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_horde_CR4, d100Roll);
+          treasureHordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HORDE_CR4, d100Roll);
         }
         else if (maximumCRFromGroup <= 10)
         {
@@ -894,26 +894,26 @@ class SFLocalHelpers {
           currencyResultObject["sp"] += this.getRollResult("2d6") * 1000;
           currencyResultObject["gp"] += this.getRollResult("6d6") * 100;
           currencyResultObject["pp"] += this.getRollResult("3d6") * 10;
-          treasurehordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_horde_CR10, d100Roll);
+          treasureHordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HORDE_CR10, d100Roll);
         }
         else if (maximumCRFromGroup <= 16)
         {
           currencyResultObject["gp"] += this.getRollResult("4d6") * 1000;
           currencyResultObject["pp"] += this.getRollResult("5d6") * 100;
-          treasurehordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_horde_CR16, d100Roll);
+          treasureHordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HORDE_CR16, d100Roll);
         }
         else
         {
           currencyResultObject["gp"] += this.getRollResult("12d6") * 1000;
           currencyResultObject["pp"] += this.getRollResult("8d6") * 1000;
-          treasurehordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_horde_CR17_PLUS, d100Roll);
+          treasureHordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HORDE_CR17_PLUS, d100Roll);
         }
   
         try
         {
-          let gemOrArtRowContents = treasurehordeRowContents[0];
+          let gemOrArtRowContents = treasureHordeRowContents[0];
           otherResultObject = SFLocalHelpers.getArtOrGemsResult(gemOrArtRowContents);
-          let magicItemsRowContents = treasurehordeRowContents[1];
+          let magicItemsRowContents = treasureHordeRowContents[1];
           itemsResultObject = SFLocalHelpers.getMagicItemResult(magicItemsRowContents);
         }
         catch (error)

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -759,7 +759,7 @@ class SFLocalHelpers {
       }
       else
       {
-        generatedLoot = SFLocalHelpers.getTreasureHoardForEncounter(currentEncounter);
+        generatedLoot = SFLocalHelpers.getTreasurehordeForEncounter(currentEncounter);
       }
   
       return generatedLoot;
@@ -801,19 +801,19 @@ class SFLocalHelpers {
             let individualTreasureRowContents;
             if (monsterCR <= 4)
             {
-              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasureHoardTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR4, d100Roll);
+              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR4, d100Roll);
             }
             else if (monsterCR <= 10)
             {
-              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasureHoardTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR10, d100Roll);
+              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR10, d100Roll);
             }
             else if (monsterCR <= 16)
             {
-              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasureHoardTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR16, d100Roll);
+              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR16, d100Roll);
             }
             else
             {
-              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasureHoardTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR17_PLUS, d100Roll);
+              individualTreasureRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_INDIVIDUAL_TREASURE_CR17_PLUS, d100Roll);
             }
   
             currencyResultObject["cp"] += SFLocalHelpers.getCoinsResultFromRollTable(individualTreasureRowContents[0]);
@@ -846,7 +846,7 @@ class SFLocalHelpers {
       return totalCoins;
     }
   
-    static getTreasureHoardForEncounter(currentEncounter)
+    static getTreasurehordeForEncounter(currentEncounter)
     {
       let creatures = currentEncounter["creatures"];
       let lootResultObject = {};
@@ -880,13 +880,13 @@ class SFLocalHelpers {
   
         let d100Roll = this.getRollResult("1d100");
   
-        let treasureHoardRowContents;
+        let treasurehordeRowContents;
         if (maximumCRFromGroup <= 4)
         {
           currencyResultObject["cp"] += this.getRollResult("6d6") * 100;
           currencyResultObject["sp"] += this.getRollResult("3d6") * 100;
           currencyResultObject["gp"] += this.getRollResult("2d6") * 10;
-          treasureHoardRowContents = SFLocalHelpers.getResultFromTreasureHoardTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HOARD_CR4, d100Roll);
+          treasurehordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_horde_CR4, d100Roll);
         }
         else if (maximumCRFromGroup <= 10)
         {
@@ -894,31 +894,31 @@ class SFLocalHelpers {
           currencyResultObject["sp"] += this.getRollResult("2d6") * 1000;
           currencyResultObject["gp"] += this.getRollResult("6d6") * 100;
           currencyResultObject["pp"] += this.getRollResult("3d6") * 10;
-          treasureHoardRowContents = SFLocalHelpers.getResultFromTreasureHoardTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HOARD_CR10, d100Roll);
+          treasurehordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_horde_CR10, d100Roll);
         }
         else if (maximumCRFromGroup <= 16)
         {
           currencyResultObject["gp"] += this.getRollResult("4d6") * 1000;
           currencyResultObject["pp"] += this.getRollResult("5d6") * 100;
-          treasureHoardRowContents = SFLocalHelpers.getResultFromTreasureHoardTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HOARD_CR16, d100Roll);
+          treasurehordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_horde_CR16, d100Roll);
         }
         else
         {
           currencyResultObject["gp"] += this.getRollResult("12d6") * 1000;
           currencyResultObject["pp"] += this.getRollResult("8d6") * 1000;
-          treasureHoardRowContents = SFLocalHelpers.getResultFromTreasureHoardTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_HOARD_CR17_PLUS, d100Roll);
+          treasurehordeRowContents = SFLocalHelpers.getResultFromTreasurehordeTable(SFLOCALCONSTS.ENCOUNTER_TREASURE_horde_CR17_PLUS, d100Roll);
         }
   
         try
         {
-          let gemOrArtRowContents = treasureHoardRowContents[0];
+          let gemOrArtRowContents = treasurehordeRowContents[0];
           otherResultObject = SFLocalHelpers.getArtOrGemsResult(gemOrArtRowContents);
-          let magicItemsRowContents = treasureHoardRowContents[1];
+          let magicItemsRowContents = treasurehordeRowContents[1];
           itemsResultObject = SFLocalHelpers.getMagicItemResult(magicItemsRowContents);
         }
         catch (error)
         {
-          console.error(`Unable to generate treasure hoard for maximum CR ${maximumCRFromGroup} and d100 roll of ${d100Roll}. Error: ${error}`);
+          console.error(`Unable to generate treasure horde for maximum CR ${maximumCRFromGroup} and d100 roll of ${d100Roll}. Error: ${error}`);
         }
       }
   
@@ -929,7 +929,7 @@ class SFLocalHelpers {
       return lootResultObject;
     }
   
-    static getResultFromTreasureHoardTable(rollTable, rollResult)
+    static getResultFromTreasurehordeTable(rollTable, rollResult)
     {
       let rowSelected;
       for (let key in rollTable)
@@ -1081,7 +1081,7 @@ class SFLocalHelpers {
       }
   
       let randomItemNumber = Math.floor(Math.random() * maxNumberToRollFor) + 1;
-      return SFLocalHelpers.getResultFromTreasureHoardTable(rollTable, randomItemNumber);
+      return SFLocalHelpers.getResultFromTreasurehordeTable(rollTable, randomItemNumber);
     }
   
     static getMagicItemTable(regexMatchResultGroups)

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -599,88 +599,150 @@ class SFLocalHelpers {
       let targetEncounterXP = SFLOCALCONSTS.ENCOUNTER_DIFFICULTY_XP_TABLES[targetedDifficulty][averageLevelOfPlayers - 1] * numberOfPlayers;
       let currentEncounterXP = 0;
       let numberOfMonstersInCombat = 0;
-  
-      let j = 0;
-      while (j < 50) // attempt to put in 50 monsters before giving up so we don't spin forever
+      let encounterType = params.encounterType;
+      let encounterTypeInformation = SFLOCALCONSTS.ENCOUNTER_TYPE_DESCRIPTIONS[encounterType];
+      if (encounterType === "Random")
       {
-        j++;
-        let randomMonsterIndex = Math.floor((Math.random() * monsterList.length));
-        let randomMonster = monsterList[randomMonsterIndex];
-        let monsterName;
-
-        try
+        let j = 0;
+        while (j < 50) // attempt to put in 50 monsters before giving up so we don't spin forever
         {
-          monsterName = randomMonster.name;
-          if (!randomMonster.data || !randomMonster.data.data)
+          j++;
+          let randomMonsterIndex = Math.floor((Math.random() * monsterList.length));
+          let randomMonster = monsterList[randomMonsterIndex];
+          let monsterName;
+  
+          try
           {
-            console.warn(`Monster chosen ${randomMonster.name} didn't have a valid data property.`)
-            continue;
+            monsterName = randomMonster.name;
+            if (!randomMonster.data || !randomMonster.data.data)
+            {
+              console.warn(`Monster chosen ${randomMonster.name} didn't have a valid data property.`)
+              continue;
+            }
+  
+            let randomMonsterXP = randomMonster.data.data.details.xp.value;
+            let currentEncounterXPMultiplier = SFLocalHelpers.getCurrentEncounterXPMultiplier(numberOfMonstersInCombat);
+            let monsterCR = randomMonster.data.data.details.cr;
+            let currentEncounterAdjustedXP = SFLocalHelpers.getAdjustedXPOfEncounter(currentEncounter);
+      
+            // If we're within 10% of budget, let's stop
+            if (currentEncounterAdjustedXP > targetEncounterXP * 0.9)
+            {
+              break;
+            }
+      
+            let nextEncounterXPMultiplier = SFLocalHelpers.getCurrentEncounterXPMultiplier(numberOfMonstersInCombat + 1);
+      
+            // If adding a single extra creature with no added XP boosts us over the XP target, just exit now.
+            if (currentEncounterXP * nextEncounterXPMultiplier > targetEncounterXP)
+            {
+              break;
+            }
+      
+            if (!randomMonsterXP)
+            {
+              continue;
+            }
+      
+            if (!monsterCR || monsterCR == 0)
+            {
+              // Boring monster
+              continue;
+            }
+      
+            let numberOfMonstersAllowedInCombat = SFLocalHelpers.getNumberOfMonstersAllowedInCombat(currentEncounter, monsterList, targetEncounterXP, randomMonster);
+      
+            if (numberOfMonstersAllowedInCombat == 0)
+            {
+              console.log(`Monster: ${monsterName}, XP: ${randomMonsterXP}, CR: ${monsterCR} too dangerous`);
+              continue;
+            }
+      
+            if (numberOfMonstersAllowedInCombat > 20)
+            {
+              console.log(`Monster: ${monsterName}, XP: ${randomMonsterXP}, CR: ${monsterCR} too weak to be interesting in combat...`);
+              continue;
+            }
+      
+            // Choose a random number of creatures to put in combat based on the max allowed number but put a maximum of 10 in combat
+            let numberOfMonstersToPutInCombat = Math.min(Math.floor((Math.random() * numberOfMonstersAllowedInCombat)) + 1, 10);
+            let creatureCombatDetails = {};
+            creatureCombatDetails["name"] = monsterName;
+            creatureCombatDetails["quantity"] = numberOfMonstersToPutInCombat;
+            creatureCombatDetails["cr"] = monsterCR;
+            creatureCombatDetails["xp"] = randomMonsterXP;
+            creatureCombatDetails["combatdata"] = this.allMonsters.find(m => m.actorid === randomMonster.id).combatdata;
+            currentEncounter["creatures"].push(creatureCombatDetails);
+            numberOfMonstersInCombat += numberOfMonstersToPutInCombat;
+            currentEncounterXP += randomMonsterXP * numberOfMonstersToPutInCombat;
           }
-
-          let randomMonsterXP = randomMonster.data.data.details.xp.value;
-          let currentEncounterXPMultiplier = SFLocalHelpers.getCurrentEncounterXPMultiplier(numberOfMonstersInCombat);
-          let monsterCR = randomMonster.data.data.details.cr;
-          let currentEncounterAdjustedXP = SFLocalHelpers.getAdjustedXPOfEncounter(currentEncounter);
-    
-          // If we're within 10% of budget, let's stop
-          if (currentEncounterAdjustedXP > targetEncounterXP * 0.9)
+          catch (error)
           {
-            break;
+            console.warn(`Failed to correctly add a random monster to the encounter. randomMonsterIndex: ${randomMonsterIndex}, monster name: ${monsterName}, Error: ${error}`);
           }
-    
-          let nextEncounterXPMultiplier = SFLocalHelpers.getCurrentEncounterXPMultiplier(numberOfMonstersInCombat + 1);
-    
-          // If adding a single extra creature with no added XP boosts us over the XP target, just exit now.
-          if (currentEncounterXP * nextEncounterXPMultiplier > targetEncounterXP)
-          {
-            break;
-          }
-    
-          if (!randomMonsterXP)
-          {
-            continue;
-          }
-    
-          if (!monsterCR || monsterCR == 0)
-          {
-            // Boring monster
-            continue;
-          }
-    
-          let numberOfMonstersAllowedInCombat = SFLocalHelpers.getNumberOfMonstersAllowedInCombat(currentEncounter, monsterList, targetEncounterXP, randomMonster);
-    
-          if (numberOfMonstersAllowedInCombat == 0)
-          {
-            console.log(`Monster: ${monsterName}, XP: ${randomMonsterXP}, CR: ${monsterCR} too dangerous`);
-            continue;
-          }
-    
-          if (numberOfMonstersAllowedInCombat > 20)
-          {
-            console.log(`Monster: ${monsterName}, XP: ${randomMonsterXP}, CR: ${monsterCR} too weak to be interesting in combat...`);
-            continue;
-          }
-    
-          // Choose a random number of creatures to put in combat based on the max allowed number but put a maximum of 10 in combat
-          let numberOfMonstersToPutInCombat = Math.min(Math.floor((Math.random() * numberOfMonstersAllowedInCombat)) + 1, 10);
-          let creatureCombatDetails = {};
-          creatureCombatDetails["name"] = monsterName;
-          creatureCombatDetails["quantity"] = numberOfMonstersToPutInCombat;
-          creatureCombatDetails["cr"] = monsterCR;
-          creatureCombatDetails["xp"] = randomMonsterXP;
-          creatureCombatDetails["combatdata"] = this.allMonsters.find(m => m.actorid === randomMonster.id).combatdata;
-          currentEncounter["creatures"].push(creatureCombatDetails);
-          numberOfMonstersInCombat += numberOfMonstersToPutInCombat;
-          currentEncounterXP += randomMonsterXP * numberOfMonstersToPutInCombat;
-        }
-        catch (error)
-        {
-          console.warn(`Failed to correctly add a random monster to the encounter. randomMonsterIndex: ${randomMonsterIndex}, monster name: ${monsterName}, Error: ${error}`);
         }
       }
-  
+      else
+      {
+        for (var i = 0; i < encounterTypeInformation.length; i++)
+        {
+          let currentEncounterDescription = encounterTypeInformation[i];
+          let creatureDescriptionParts = currentEncounterDescription.split(":");
+
+          if (creatureDescriptionParts.length != 2)
+          {
+            console.error(`Encounter type description is invalid. Expected format of number:formula. For example: 2:0.3*x. This would choose 2 creatures that are roughly near 30% of the the target encounter XP. Actual: ${currentEncounterDescription}`);
+            return;
+          }
+          let numberOfCreatures = creatureDescriptionParts[0];
+          let formula = creatureDescriptionParts[1];
+          let formulaMatch = formula.match(/(?<multiplier>(\d+)?\.?\d+)\*x/i);
+
+          if (!formulaMatch)
+          {
+            console.error(`Encounter formula is invalid. Expected format of formula: 2:0.3*x. This would choose a creatures that is roughly near 30% of the the target encounter XP.`);
+            return;
+          }
+          let formulaMatchGroups = formulaMatch.groups;
+          let multiplierAmount = formulaMatchGroups.multiplier;
+
+          if (!multiplierAmount)
+          {
+            multiplierAmount = 1;
+          }
+
+          // Have ever exanding wiggle roomsto find more nad more monsters. 
+          let wiggleRoomAmounts = [0.1, 0.2, 0.3];
+
+          for (var j = 0; j < wiggleRoomAmounts.length; j++)
+          {
+            let wiggleRoom = wiggleRoomAmounts[j];
+            let lowerBound = multiplierAmount * targetEncounterXP * (1 - wiggleRoom);
+            let upperBound = multiplierAmount * targetEncounterXP * (1 + wiggleRoom);
+            let filteredMonsterList = monsterList.filter(m => m.data.data.details.xp.value >= lowerBound && m.data.data.details.xp.value <= upperBound);
+            if (filteredMonsterList.length === 0)
+            {
+              continue;
+            }
+
+            let randomMonsterIndex = Math.floor((Math.random() * filteredMonsterList.length));
+            let randomMonster = filteredMonsterList[randomMonsterIndex];
+            let monsterName = randomMonster.name;
+            let randomMonsterXP = randomMonster.data.data.details.xp.value;
+            let monsterCR = randomMonster.data.data.details.cr;
+            let creatureCombatDetails = {};
+            creatureCombatDetails["name"] = monsterName;
+            creatureCombatDetails["quantity"] = numberOfCreatures;
+            creatureCombatDetails["cr"] = monsterCR;
+            creatureCombatDetails["xp"] = randomMonsterXP;
+            creatureCombatDetails["combatdata"] = this.allMonsters.find(m => m.actorid === randomMonster.id).combatdata;
+            currentEncounter["creatures"].push(creatureCombatDetails);
+            break;
+          }
+        }
+      }
+
       currentEncounter["xp"] = SFLocalHelpers.getAdjustedXPOfEncounter(currentEncounter);
-      
       let generatedLootObject = SFLocalHelpers.getLootForEncounter(currentEncounter, params);
       currentEncounter["loot"] = generatedLootObject;
       return currentEncounter;

--- a/scripts/localmodule.js
+++ b/scripts/localmodule.js
@@ -918,7 +918,7 @@ class SFLocalHelpers {
         }
         catch (error)
         {
-          console.error(`Unable to generate treasure horde for maximum CR ${maximumCRFromGroup} and d100 roll of ${d100Roll}. Error: ${error}`);
+          console.error(`Unable to generate Treasure Horde for maximum CR ${maximumCRFromGroup} and d100 roll of ${d100Roll}. Error: ${error}`);
         }
       }
   

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,7 +1,7 @@
 const SFCONSTS = {
     MODULE_NAME: "dnd-randomizer",
     GEN_OPT: {
-        loot_type: ["individual treasure", "treasure horde"],
+        loot_type: ["individual treasure", "Treasure Horde"],
         numberOfPlayers: Number,//[1 - 13]
         averageLevelOfPlayers: Number,//[1 - 20]
         environment: [

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -79,5 +79,5 @@ async function dataTest(){
 }
 
 async function fetchTest(){
-    return await fetch('https://theripper93.com/encounterData.php?loot_type=Treasure+horde').then(response => response.json()).then(data => data);
+    return await fetch('https://theripper93.com/encounterData.php?loot_type=Treasure+Hoard').then(response => response.json()).then(data => data);
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,7 +1,7 @@
 const SFCONSTS = {
     MODULE_NAME: "dnd-randomizer",
     GEN_OPT: {
-        loot_type: ["individual treasure", "treasure hoard"],
+        loot_type: ["individual treasure", "treasure horde"],
         numberOfPlayers: Number,//[1 - 13]
         averageLevelOfPlayers: Number,//[1 - 20]
         environment: [
@@ -79,5 +79,5 @@ async function dataTest(){
 }
 
 async function fetchTest(){
-    return await fetch('https://theripper93.com/encounterData.php?loot_type=Treasure+Hoard').then(response => response.json()).then(data => data);
+    return await fetch('https://theripper93.com/encounterData.php?loot_type=Treasure+horde').then(response => response.json()).then(data => data);
 }

--- a/templates/dialog.hbs
+++ b/templates/dialog.hbs
@@ -6,8 +6,11 @@
 				<span class="placeholder">Single BBEG</span>
 				<span class="input selectbox">
 					<select class="fancy-select hidden" name="encounterType">
-						<option value="Random">Random</option>
 						<option value="Single BBEG" selected>Single BBEG</option>
+						<option value="BBEG + 2 Minions" selected>BBEG + 2 Minions</option>
+						<option value="2 Semi-BBEG" selected>2 Semi-BBEG</option>
+						<option value="Monster Hoard" selected>Monster Hoard</option>
+						<option value="Random">Random</option>
 					</select>
 				</span>
 			</span>

--- a/templates/dialog.hbs
+++ b/templates/dialog.hbs
@@ -76,11 +76,11 @@
 				</span>
 			</span>. They will find  
 			<span id="lootType" class="input-container">
-				<span class="placeholder">Treasure horde</span>
+				<span class="placeholder">Treasure Horde</span>
 				<span class="input selectbox">
 					<select class="fancy-select hidden" name="lootType">
 						<option value="Individual Treasure">Individual Treasure</option>
-						<option value="Treasure horde" selected>Treasure horde</option>
+						<option value="Treasure Horde" selected>Treasure Horde</option>
 					</select>
 				</span>
 			</span>

--- a/templates/dialog.hbs
+++ b/templates/dialog.hbs
@@ -7,10 +7,10 @@
 				<span class="input selectbox">
 					<select class="fancy-select hidden" name="encounterType">
 						<option value="Single BBEG" selected>Single BBEG</option>
-						<option value="BBEG + 2 Minions" selected>BBEG + 2 Minions</option>
-						<option value="2 Semi-BBEG" selected>2 Semi-BBEG</option>
-						<option value="BBEG + Monster horde" selected>2 Semi-BBEG</option>
-						<option value="Monster horde" selected>Monster horde</option>
+						<option value="BBEG + 2 Minions">BBEG + 2 Minions</option>
+						<option value="2 Semi-BBEG">2 Semi-BBEG</option>
+						<option value="BBEG + Monster horde">BBEG + Monster horde</option>
+						<option value="Monster horde">Monster horde</option>
 						<option value="Random">Random</option>
 					</select>
 				</span>

--- a/templates/dialog.hbs
+++ b/templates/dialog.hbs
@@ -9,7 +9,8 @@
 						<option value="Single BBEG" selected>Single BBEG</option>
 						<option value="BBEG + 2 Minions" selected>BBEG + 2 Minions</option>
 						<option value="2 Semi-BBEG" selected>2 Semi-BBEG</option>
-						<option value="Monster Hoard" selected>Monster Hoard</option>
+						<option value="BBEG + Monster horde" selected>2 Semi-BBEG</option>
+						<option value="Monster horde" selected>Monster horde</option>
 						<option value="Random">Random</option>
 					</select>
 				</span>
@@ -75,11 +76,11 @@
 				</span>
 			</span>. They will find  
 			<span id="lootType" class="input-container">
-				<span class="placeholder">Treasure Hoard</span>
+				<span class="placeholder">Treasure horde</span>
 				<span class="input selectbox">
 					<select class="fancy-select hidden" name="lootType">
 						<option value="Individual Treasure">Individual Treasure</option>
-						<option value="Treasure Hoard" selected>Treasure Hoard</option>
+						<option value="Treasure horde" selected>Treasure horde</option>
 					</select>
 				</span>
 			</span>

--- a/templates/dialog.hbs
+++ b/templates/dialog.hbs
@@ -1,7 +1,17 @@
 <form>
 	<div class="form-controls">
 		<div class="form-groups">
-			I'm looking for an encounter in a
+			I'm looking for an encounter (Type: 
+			<span id="encounterType" class="input-container">
+				<span class="placeholder">Single BBEG</span>
+				<span class="input selectbox">
+					<select class="fancy-select hidden" name="encounterType">
+						<option value="Random">Random</option>
+						<option value="Single BBEG" selected>Single BBEG</option>
+					</select>
+				</span>
+			</span>
+			) in a
 			<span id="environmentSelector" class="input-container">
 				<span class="placeholder">{{environments.[0]}}</span>
 				<span class="input selectbox">

--- a/templates/usePCsDialog.hbs
+++ b/templates/usePCsDialog.hbs
@@ -7,9 +7,10 @@
 				<span class="input selectbox">
 					<select class="fancy-select hidden" name="encounterType">
 						<option value="Single BBEG" selected>Single BBEG</option>
-						<option value="BBEG + 2 Minions" selected>BBEG + 2 Minions</option>
-						<option value="2 Semi-BBEG" selected>2 Semi-BBEG</option>
-						<option value="Monster horde" selected>Monster horde</option>
+						<option value="BBEG + 2 Minions">BBEG + 2 Minions</option>
+						<option value="2 Semi-BBEG">2 Semi-BBEG</option>
+						<option value="BBEG + Monster horde">BBEG + Monster horde</option>
+						<option value="Monster horde">Monster horde</option>
 						<option value="Random">Random</option>
 					</select>
 				</span>

--- a/templates/usePCsDialog.hbs
+++ b/templates/usePCsDialog.hbs
@@ -6,8 +6,11 @@
 				<span class="placeholder">Single BBEG</span>
 				<span class="input selectbox">
 					<select class="fancy-select hidden" name="encounterType">
-						<option value="Random">Random</option>
 						<option value="Single BBEG" selected>Single BBEG</option>
+						<option value="BBEG + 2 Minions" selected>BBEG + 2 Minions</option>
+						<option value="2 Semi-BBEG" selected>2 Semi-BBEG</option>
+						<option value="Monster Hoard" selected>Monster Hoard</option>
+						<option value="Random">Random</option>
 					</select>
 				</span>
 			</span>

--- a/templates/usePCsDialog.hbs
+++ b/templates/usePCsDialog.hbs
@@ -27,11 +27,11 @@
 			</span>
 			environment. They will find 
 			<span id="lootType" class="input-container">
-				<span class="placeholder">Treasure horde</span>
+				<span class="placeholder">Treasure Horde</span>
 				<span class="input selectbox">
 					<select class="fancy-select hidden" name="lootType">
 						<option value="Individual Treasure">Individual Treasure</option>
-						<option value="Treasure horde" selected>Treasure horde</option>
+						<option value="Treasure Horde" selected>Treasure Horde</option>
 					</select>
 				</span>
 			</span>

--- a/templates/usePCsDialog.hbs
+++ b/templates/usePCsDialog.hbs
@@ -9,7 +9,7 @@
 						<option value="Single BBEG" selected>Single BBEG</option>
 						<option value="BBEG + 2 Minions" selected>BBEG + 2 Minions</option>
 						<option value="2 Semi-BBEG" selected>2 Semi-BBEG</option>
-						<option value="Monster Hoard" selected>Monster Hoard</option>
+						<option value="Monster horde" selected>Monster horde</option>
 						<option value="Random">Random</option>
 					</select>
 				</span>
@@ -27,11 +27,11 @@
 			</span>
 			environment. They will find 
 			<span id="lootType" class="input-container">
-				<span class="placeholder">Treasure Hoard</span>
+				<span class="placeholder">Treasure horde</span>
 				<span class="input selectbox">
 					<select class="fancy-select hidden" name="lootType">
 						<option value="Individual Treasure">Individual Treasure</option>
-						<option value="Treasure Hoard" selected>Treasure Hoard</option>
+						<option value="Treasure horde" selected>Treasure horde</option>
 					</select>
 				</span>
 			</span>

--- a/templates/usePCsDialog.hbs
+++ b/templates/usePCsDialog.hbs
@@ -1,7 +1,17 @@
 <form>
 	<div class="form-controls">
 		<div class="form-groups">
-			I'm looking for an encounter in a
+			I'm looking for an encounter (Type: 
+			<span id="encounterType" class="input-container">
+				<span class="placeholder">Single BBEG</span>
+				<span class="input selectbox">
+					<select class="fancy-select hidden" name="encounterType">
+						<option value="Random">Random</option>
+						<option value="Single BBEG" selected>Single BBEG</option>
+					</select>
+				</span>
+			</span>
+			) in a
 			<span id="environmentSelector" class="input-container">
 				<span class="placeholder">{{environments.[0]}}</span>
 				<span class="input selectbox">


### PR DESCRIPTION
This will allow a bit more distinct encounter types that someone wants to create in addition to the PURE randomness

// Formula format ["1:.3*x","2:.1*x"] - This will create an encounter with 1 creature that is 30% of target XP and 2 creatures that are 10% target XP
"Single BBEG": ["1:1*x"],
"BBEG + 2 Minions": ["1:0.3*x","2:0.1*x"],
"2 Semi-BBEG": ["2:0.3333*x"],
"Monster Hoard": ["6:0.08333*x"],