### PR TITLE
Update to have support for Item Piles and remove support for LootSheetNPC

### DIFF
--- a/scripts/encounter.js
+++ b/scripts/encounter.js
@@ -8,6 +8,7 @@ class Encounter {
     this.creatures = [];
     this.combatsummary = {};
     this.loot = [];
+    this.lootActorId = "";
     this.id = data.id || randomID(40);
   }
 
@@ -150,6 +151,10 @@ class Encounter {
     const _this = this;
     Hooks.once("preCreateMeasuredTemplate", (template) => {
       canvas.tokens.activate();
+      if (this.lootActorId === "")
+      {
+        this.createLootSheet();
+      }
       CreatureSpawner.fromTemplate(template, _this);
       return false;
     });
@@ -173,44 +178,23 @@ class Encounter {
       data: {
         currency: {
           // If Loot sheet is missing use currency as Normal (Adds Support for other NPC Sheets such as TidySheet5e)
-          cp:
-            game.modules.get("lootsheetnpc5e")?.active ?? false
-              ? { value: this.currency.cp }
-              : this.currency.cp,
-          sp:
-            game.modules.get("lootsheetnpc5e")?.active ?? false
-              ? { value: this.currency.sp }
-              : this.currency.sp,
-          ep:
-            game.modules.get("lootsheetnpc5e")?.active ?? false
-              ? { value: this.currency.ep }
-              : this.currency.ep,
-          gp:
-            game.modules.get("lootsheetnpc5e")?.active ?? false
-              ? { value: this.currency.gp }
-              : this.currency.gp,
-          pp:
-            game.modules.get("lootsheetnpc5e")?.active ?? false
-              ? { value: this.currency.pp }
-              : this.currency.pp,
+          cp: this.currency.cp,
+          sp: this.currency.sp,
+          ep: this.currency.ep,
+          gp: this.currency.gp,
+          pp: this.currency.pp,
         },
       },
       folder: folder.id,
-      flags: {
-        core: {
-          sheetClass: "dnd5e.LootSheet5eNPC",
-        },
-        lootsheetnpc5e: {
-          lootsheettype: "Loot",
-        },
-      },
     };
+
     const actor = await Actor.create(actorData);
     let items = [];
     for (let item of this.loot) {
       items.push(await item.getData());
     }
     await actor.createEmbeddedDocuments("Item", items);
+    this.lootActorId = actor.id;
   }
 }
 

--- a/scripts/spawner.js
+++ b/scripts/spawner.js
@@ -21,8 +21,45 @@ class CreatureSpawner {
             await canvas.scene.createEmbeddedDocuments("Token", [tokenData]);
           }
         }
+
+        let lootActor =  await game.actors.get(encounterData.lootActorId)
+        const tD = await lootActor.getTokenData();
+        const position = Propagator.getFreePosition(
+          tD,
+          CreatureSpawner.randomInCircle(
+            {x:template.data.x,y:template.data.y},
+            (template.data.distance * canvas.dimensions.size) /
+            canvas.dimensions.distance
+          )
+        );
+        const tokenData = await lootActor.getTokenData({
+          x: position.x,
+          y: position.y,
+        });
+        let lootToken = await canvas.scene.createEmbeddedDocuments("Token", [tokenData]);
+        await CreatureSpawner.createItemPiles(lootToken[0]);
     }
   }
+
+  static async createItemPiles(lootToken) {
+    let isItemPilesInstalled = game.modules.get("item-piles");
+    if (!isItemPilesInstalled)
+    {
+      return;
+    }
+
+    let itemPilesIsActive = isItemPilesInstalled.active;
+
+    if (!itemPilesIsActive)
+    {
+      return;
+    }
+
+    // let currentScene = game.scenes.find(s => s.id === canvas.id);
+    // let lootTokenOnScene = currentScene.tokens.find(t => t.id === lootToken.id);
+    await ItemPiles.API.turnTokensIntoItemPiles([lootToken]);
+  }
+
   //generate a random point in a circle given a center point and a radius
   static randomInCircle(center, oradius, collision = true) {
     let attemptNumber = 0;


### PR DESCRIPTION
Seeing the following error but it doesn't seem to affect actual creation. 

`
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'bar1')
[Detected 2 packages: item-piles, dnd-randomizer]
    at foundry.js:38247:32
    at Array.forEach (<anonymous>)
    at Token5e.drawBars (foundry.js:38246:22)
    at Token5e._onUpdate (foundry.js:38895:31)
    at TokenDocument5e._onUpdate (foundry.js:9838:38)
    at TokenDocument5e._onUpdate (foundry.js:19144:18)
    at ClientDatabaseBackend.callback (foundry.js:10300:11)
    at foundry.js:10283:43
    at Array.map (<anonymous>)
    at ClientDatabaseBackend._handleUpdateEmbeddedDocuments (foundry.js:10283:33)
    at ClientDatabaseBackend._updateEmbeddedDocuments (foundry.js:10163:17)
    at async Function.updateDocuments (document.mjs:373:21)
    at async Object._turnTokensIntoItemPiles (api.js:273:13)
    at async Function.createItemPiles (spawner.js:60:5)
    at async Function.fromTemplate (spawner.js:40:9)
`